### PR TITLE
CL-540 | Lower concurrent resource list requests temporarily (for cloudcontrol)

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const ScannerParallelQueries = 16
+const ScannerParallelQueries = 2
 
 func Scan(region *Region, resourceTypes []string) <-chan *Item {
 	s := &scanner{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rebuy-de/aws-nuke/v2
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go v1.44.230
+	github.com/aws/aws-sdk-go v1.44.235
 	github.com/fatih/color v1.15.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.44.230 h1:dcn7TjLyx/31I+0XytMGYRxDc756BRUzsSYVcSyKZlk=
-github.com/aws/aws-sdk-go v1.44.230/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.235 h1:5MS1ZW1Pr27mmHFqqjuXYwGMlNTW/g6DqU5ekamPMeU=
+github.com/aws/aws-sdk-go v1.44.235/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -39,7 +39,7 @@ func init() {
 
 func NewListCloudControlResource(typeName string) func(*session.Session) ([]Resource, error) {
 	return func(sess *session.Session) ([]Resource, error) {
-		svc := cloudcontrolapi.New(sess)
+		svc := cloudcontrolapi.New(sess, aws.NewConfig().WithMaxRetries(3))
 
 		params := &cloudcontrolapi.ListResourcesInput{
 			TypeName: aws.String(typeName),

--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -39,7 +39,7 @@ func init() {
 
 func NewListCloudControlResource(typeName string) func(*session.Session) ([]Resource, error) {
 	return func(sess *session.Session) ([]Resource, error) {
-		svc := cloudcontrolapi.New(sess, aws.NewConfig().WithMaxRetries(3))
+		svc := cloudcontrolapi.New(sess)
 
 		params := &cloudcontrolapi.ListResourcesInput{
 			TypeName: aws.String(typeName),


### PR DESCRIPTION
We are seeing ThrottlingException errors for CloudControl API deleted resources. ~It seems to me that the aws-nuke cloudcontrol service client is not configured to retry. This adjusts it to allow a maximum of 3 times.~ It was noted by @corybekk that this may only occur on the scan side versus the delete side because of a difference in how the list queries were executed. 

He also noted the `ScannerParallelQueries` value being decremented could make a difference. I first tried weights of `8` with fewer occurrence of the error, then `4` with fewer still, but I've now scanned an account 20 times with a value of `2` with no occurrences at our current level of CloudControl resources without a ThrottlingException error. At least we're still technically parallelizing the requests and there's no explicit sleep in the list process!

## Testing

I have tested this repeatedly against a dev account and I am no longer able to replicate the somewhat frequent ThrottlingException error currently observed in main.