### PR TITLE
Cl 550 | Adjust cloudcontrol behavior in aws-nuke to properly handle ThrottlingExceptions

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -63,6 +63,16 @@ func (n *Nuke) Run() error {
 		return err
 	}
 
+	if n.items.Count(ItemStateFailed) > 0 && n.items.Count(ItemStateNew) == 0 {
+		for _, item := range n.items {
+			if item.State != ItemStateFailed {
+				continue
+			}
+			logrus.Error(fmt.Sprintf("%s. %s.", item.Type, item.Reason))
+		}
+		return fmt.Errorf("failed")
+	}
+
 	if n.items.Count(ItemStateNew) == 0 {
 		fmt.Println("No resource to delete.")
 		return nil
@@ -249,9 +259,9 @@ func (n *Nuke) HandleQueue() {
 			n.HandleRemove(item)
 			item.Print()
 		case ItemStateFailed:
-			// item.Resource will be nil if an exception was thrown while retrieving the resourceType's
-			// items (I.E resourceTypes lister()), however we still pass down the reason and state so we
-			// aren't ignoring these exceptions.
+			// item.Resource will be nil if an exception was thrown while retrieving cloudControl
+			// resourceType's items (I.E resourceTypes lister()), however we still pass down the
+			// reason and state so we aren't ignoring these exceptions.
 			if item.Resource != nil {
 				n.HandleRemove(item)
 				n.HandleWait(item, listCache)

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -249,9 +249,14 @@ func (n *Nuke) HandleQueue() {
 			n.HandleRemove(item)
 			item.Print()
 		case ItemStateFailed:
-			n.HandleRemove(item)
-			n.HandleWait(item, listCache)
-			item.Print()
+			// item.Resource will be nil if an exception was thrown while retrieving the resourceType's
+			// items (I.E resourceTypes lister()), however we still pass down the reason and state so we
+			// aren't ignoring these exceptions.
+			if item.Resource != nil {
+				n.HandleRemove(item)
+				n.HandleWait(item, listCache)
+				item.Print()
+			}
 		case ItemStatePending:
 			n.HandleWait(item, listCache)
 			item.State = ItemStateWaiting

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const ScannerParallelQueries = 2
+const ScannerParallelQueries = 16
 
 func Scan(region *Region, resourceTypes []string) <-chan *Item {
 	s := &scanner{

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -73,9 +73,6 @@ func (s *scanner) list(region *Region, resourceType string) {
 			return
 		}
 
-		// check for this error "ThrottlingException: Rate exceeded"
-		// TODO: if there is a throttling exception call lister(sess) again 3 times with exponential backoff.
-		// or maybe try recursion and call s.list(region, resourceType)
 		awsErr, ok := err.(awserr.Error)
 		if ok && awsErr.Code() == "ThrottlingException" {
 			s.items <- &Item{
@@ -85,6 +82,8 @@ func (s *scanner) list(region *Region, resourceType string) {
 				Reason:   err.Error(),
 				Type:     resourceType,
 			}
+			dump := util.Indent(fmt.Sprintf("%v", err), "    ")
+			log.Errorf("Listing %s failed:\n%s", resourceType, dump)
 			return
 		}
 

--- a/resources/cloudcontrol.go
+++ b/resources/cloudcontrol.go
@@ -37,9 +37,11 @@ func init() {
 	registerCloudControl("AWS::NetworkFirewall::RuleGroup")
 }
 
+const CloudControlAPiMaxRetries = 5
+
 func NewListCloudControlResource(typeName string) func(*session.Session) ([]Resource, error) {
 	return func(sess *session.Session) ([]Resource, error) {
-		svc := cloudcontrolapi.New(sess)
+		svc := cloudcontrolapi.New(sess, &aws.Config{MaxRetries: aws.Int(CloudControlAPiMaxRetries)})
 
 		params := &cloudcontrolapi.ListResourcesInput{
 			TypeName: aws.String(typeName),


### PR DESCRIPTION
Description
--
- reset ScannerParallelQueries back to 16 
- added cloudcontrolapi maxRetry api config to 5. This seems to have fixed the throttling exceptions we had before.
- added logic to `scan.go` and` nuke.go` that allows us to pass down a a resource types `ItemStateFailed` to `n.Run()`. This ultimately allows us to return a cloudControlApi error without effecting the other resources cleanup process's

Observations
--
- This is my theory on the throttling exception we are seeing. When a resource is scanned, `region.go` creates a session for the resource + region and cache's it using the resourceName as the key. In the config.yaml file, adding the **same** cloud control resource to the `target` and `cloud-control` block will make the resource use the same session during a scan, but  in separate goroutine tasks. So basically, these sessions are being used to run multiple concurrent tasks, which "overloads" a session. 

Testing 
--
- I tried getting throttling exceptions multiple ways and succeeded on all accounts, but found the most straight forward was to create a config.yaml like below and set `const CloudControlAPiMaxRetries = 0`. Still not working? just add more resourcesTypes to the config file. 

example
```
resource-types:
      cloud-control:
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
        - AWS::EC2::NetworkInsightsAccessScope
Targets
  - AWS::EC2::NetworkInsightsAccessScope
```

Results
--
Logs that show the retry behavior working

```
---[ REQUEST POST-SIGN ]-----------------------------
2023/05/31 21:08:09 DEBUG: Retrying Request CloudControl/ListResources, attempt 3
2023/05/31 21:08:09 DEBUG: Request CloudControl/ListResources Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: cloudcontrolapi.us-east-1.amazonaws.com
User-Agent: aws-sdk-go/1.44.245 (go1.20.3; linux; amd64)
Content-Length: 51
Authorization: AWS4-HMAC-SHA256 Credential=ASIAVTFA3KAXJDU6S4UX/20230531/us-east-1/cloudcontrolapi/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=f0429e1ccf1045574264970bd07196c83e41715feb3a
Content-Type: application/x-amz-json-1.0
X-Amz-Date: 20230531T210809Z
X-Amz-Security-Token: 
X-Amz-Target: CloudApiService.ListResources
Accept-Encoding: gzip

-----------------------------------------------------
2023/05/31 21:08:09 DEBUG: Retrying Request CloudControl/ListResources, attempt 4
2023/05/31 21:08:09 DEBUG: Request CloudControl/ListResources Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: cloudcontrolapi.us-east-1.amazonaws.com
User-Agent: aws-sdk-go/1.44.245 (go1.20.3; linux; amd64)
Content-Length: 51
Authorization: AWS4-HMAC-SHA256 Credential=ASIAVTFA3KAXJDU6S4UX/20230531/us-east-1/cloudcontrolapi/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=f0429e1ccf1045574264970bd071
Content-Type: application/x-amz-json-1.0
X-Amz-Date: 20230531T210809Z
X-Amz-Security-Token: 
X-Amz-Target: CloudApiService.ListResources
Accept-Encoding: gzip

-----------------------------------------------------
2023/05/31 21:08:10 DEBUG: Response CloudControl/ListResources Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 77
Content-Type: application/x-amz-json-1.0
Date: Wed, 31 May 2023 21:08:10 GMT
X-Amzn-Requestid: cce10f00-558e-4eac-aa8f-a32c713c9694

-----------------------------------------------------
```

A non zero code for throttling exceptions **AFTER** items have been cleaned. This follows the original error format.


```
Removal requested: 0 waiting, 16 failed, 111 skipped, 1 finished


us-west-2 - AWS::Lightsail::Database - failed
us-west-2 - AWS::Lightsail::Distribution - failed
us-west-2 - AWS::Logs::QueryDefinition - failed
us-west-2 - AWS::Route53::CidrCollection - failed
us-west-2 - AWS::Route53::DNSSEC - failed
us-west-2 - AWS::Route53::KeySigningKey - failed
us-west-2 - AWS::Route53Resolver::ResolverDNSSECConfig - failed
us-west-2 - AWS::Route53Resolver::ResolverConfig - failed
us-west-2 - AWS::Route53Resolver::ResolverQueryLoggingConfig - failed
us-west-2 - AWS::SES::ContactList - failed
us-west-2 - AWS::Signer::ProfilePermission - failed
us-west-2 - AWS::Signer::SigningProfile - failed
us-west-2 - AWS::SES::DedicatedIpPool - failed
us-east-1 - AWS::SES::ContactList - failed
us-east-1 - AWS::Signer::ProfilePermission - failed
us-east-1 - AWS::Signer::SigningProfile - failed
time="2023-05-31T22:43:33Z" level=error msg="There are resources in failed state, but none are ready for deletion, anymore."
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
time="2023-05-31T22:43:33Z" level=error msg="ThrottlingException: Rate exceeded"
Error: failed
```

A non zero code being returned for throttling exceptions **even if no new items have been found**. This follows the Cory error format. I'm on the fence on whether I should change this to match the above? I originally changed it because the errors were grouped and it was hard to discern which one belonged to which.


```
Scan complete: 129 total, 0 nukeable, 111 filtered.

time="2023-05-31T22:55:58Z" level=error msg="AWS::Lightsail::Container. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Lightsail::Distribution. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Logs::QueryDefinition. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53::CidrCollection. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53::DNSSEC. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53::KeySigningKey. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53Resolver::ResolverConfig. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53Resolver::ResolverQueryLoggingConfig. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::SES::ContactList. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::SES::DedicatedIpPool. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Signer::ProfilePermission. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Signer::SigningProfile. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::SES::DedicatedIpPool. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53Resolver::ResolverQueryLoggingConfig. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Route53Resolver::ResolverDNSSECConfig. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::SES::ContactList. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Signer::ProfilePermission. ThrottlingException: Rate exceeded."
time="2023-05-31T22:55:58Z" level=error msg="AWS::Signer::SigningProfile. ThrottlingException: Rate exceeded."
Error: failed
Process 4559 has exited with status 255
Detaching
```
