### PR TITLE
Add Polly Lexicon support

### DIFF
--- a/resources/polly-lexicons.go
+++ b/resources/polly-lexicons.go
@@ -7,8 +7,9 @@ import (
 )
 
 type PollyLexicon struct {
-	svc  *polly.Polly
-	name *string
+	svc        *polly.Polly
+	name       *string
+	attributes *polly.LexiconAttributes
 }
 
 func init() {
@@ -27,8 +28,9 @@ func ListPollyLexicons(sess *session.Session) ([]Resource, error) {
 	}
 	for _, lexicon := range listOutput.Lexicons {
 		resources = append(resources, &PollyLexicon{
-			svc:  svc,
-			name: lexicon.Name,
+			svc:        svc,
+			name:       lexicon.Name,
+			attributes: lexicon.Attributes,
 		})
 	}
 	return resources, nil
@@ -45,5 +47,11 @@ func (lexicon *PollyLexicon) Remove() error {
 func (lexicon *PollyLexicon) Properties() types.Properties {
 	properties := types.NewProperties()
 	properties.Set("Name", lexicon.name)
+	properties.Set("Alphabet", lexicon.attributes.Alphabet)
+	properties.Set("LanguageCode", lexicon.attributes.LanguageCode)
+	properties.Set("LastModified", lexicon.attributes.LastModified)
+	properties.Set("LexemesCount", lexicon.attributes.LexemesCount)
+	properties.Set("LexiconArn", lexicon.attributes.LexiconArn)
+	properties.Set("Size", lexicon.attributes.Size)
 	return properties
 }

--- a/resources/polly-lexicons.go
+++ b/resources/polly-lexicons.go
@@ -1,0 +1,49 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/polly"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type PollyLexicon struct {
+	svc  *polly.Polly
+	name *string
+}
+
+func init() {
+	register("PollyLexicons", ListPollyLexicons)
+}
+
+func ListPollyLexicons(sess *session.Session) ([]Resource, error) {
+	svc := polly.New(sess)
+	resources := []Resource{}
+
+	listLexiconsInput := &polly.ListLexiconsInput{}
+
+	listOutput, err := svc.ListLexicons(listLexiconsInput)
+	if err != nil {
+		return nil, err
+	}
+	for _, lexicon := range listOutput.Lexicons {
+		resources = append(resources, &PollyLexicon{
+			svc:  svc,
+			name: lexicon.Name,
+		})
+	}
+	return resources, nil
+}
+
+func (lexicon *PollyLexicon) Remove() error {
+	deleteInput := &polly.DeleteLexiconInput{
+		Name: lexicon.name,
+	}
+	_, err := lexicon.svc.DeleteLexicon(deleteInput)
+	return err
+}
+
+func (lexicon *PollyLexicon) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", lexicon.name)
+	return properties
+}


### PR DESCRIPTION
https://github.com/oreillymedia/aws-nuke/pull/5/commits/3970cd2ee38e355d29b97fae9a138db7eee700a9 This adds [Polly](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/polly/index.html) support by removing the only resource the service manages outside of sound files output to local or S3; [Lexicons](https://docs.aws.amazon.com/polly/latest/dg/gs-put-lexicon.html).

Tested/expected output of removal:
```
us-east-1 - PollyLexicons - [Name: "testlexicon"] - triggered remove
...
us-east-1 - PollyLexicons - [Name: "testlexicon"] - waiting
...
us-east-1 - PollyLexicons - [Name: "testlexicon"] - removed
```