### PR TITLE
Add opensearch packages vpc endpoint support

### DIFF
--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -1,14 +1,18 @@
 package resources
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 )
 
 type OSPackage struct {
-	svc       *opensearchservice.OpenSearchService
-	packageID *string
+	svc         *opensearchservice.OpenSearchService
+	packageID   *string
+	packageName *string
+	createdTime *time.Time
 }
 
 func init() {
@@ -27,8 +31,10 @@ func ListOSPackages(sess *session.Session) ([]Resource, error) {
 
 	for _, pkg := range listResp.PackageDetailsList {
 		resources = append(resources, &OSPackage{
-			svc:       svc,
-			packageID: pkg.PackageID,
+			svc:         svc,
+			packageID:   pkg.PackageID,
+			packageName: pkg.PackageName,
+			createdTime: pkg.CreatedAt,
 		})
 	}
 
@@ -45,6 +51,9 @@ func (o *OSPackage) Remove() error {
 
 func (o *OSPackage) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("PackageID", o.packageID)
+	properties.Set("PackageName", o.packageName)
+	properties.Set("CreatedTime", o.createdTime.Format(time.RFC3339))
 	return properties
 }
 

--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -1,0 +1,64 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type OSPackage struct {
+	svc        *opensearchservice.OpenSearchService
+	domainName *string
+	packageID  *string
+}
+
+func init() {
+	register("OSPackage", ListOSPackages)
+}
+
+func ListOSPackages(sess *session.Session) ([]Resource, error) {
+	svc := opensearchservice.New(sess)
+
+	listResp, err := svc.DescribePackages(&opensearchservice.DescribePackagesInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+
+	for _, pkg := range listResp.PackageDetailsList {
+		domainResp, err := svc.ListDomainsForPackage(&opensearchservice.ListDomainsForPackageInput{
+			PackageID: pkg.PackageID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, domain := range domainResp.DomainPackageDetailsList {
+			resources = append(resources, &OSPackage{
+				svc:        svc,
+				domainName: domain.DomainName,
+				packageID:  pkg.PackageID,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (o *OSPackage) Remove() error {
+	_, err := o.svc.DeletePackage(&opensearchservice.DeletePackageInput{
+		PackageID: o.packageID,
+	})
+
+	return err
+}
+
+func (o *OSPackage) Properties() types.Properties {
+	properties := types.NewProperties()
+	return properties
+}
+
+func (o *OSPackage) String() string {
+	return *o.packageID
+}

--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -7,9 +7,8 @@ import (
 )
 
 type OSPackage struct {
-	svc        *opensearchservice.OpenSearchService
-	domainName *string
-	packageID  *string
+	svc       *opensearchservice.OpenSearchService
+	packageID *string
 }
 
 func init() {

--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -27,20 +27,10 @@ func ListOSPackages(sess *session.Session) ([]Resource, error) {
 	resources := make([]Resource, 0)
 
 	for _, pkg := range listResp.PackageDetailsList {
-		domainResp, err := svc.ListDomainsForPackage(&opensearchservice.ListDomainsForPackageInput{
-			PackageID: pkg.PackageID,
+		resources = append(resources, &OSPackage{
+			svc:       svc,
+			packageID: pkg.PackageID,
 		})
-		if err != nil {
-			return nil, err
-		}
-
-		for _, domain := range domainResp.DomainPackageDetailsList {
-			resources = append(resources, &OSPackage{
-				svc:        svc,
-				domainName: domain.DomainName,
-				packageID:  pkg.PackageID,
-			})
-		}
 	}
 
 	return resources, nil

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -67,6 +67,7 @@ func (o *OSVPCEndpoint) Remove() error {
 
 func (o *OSVPCEndpoint) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("VpcEndpointId", o.vpcEndpointId)
 	return properties
 }
 

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -1,0 +1,55 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/opensearchservice"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type OSVPCEndpoint struct {
+	svc           *opensearchservice.OpenSearchService
+	vpcEndpointId *string
+}
+
+func init() {
+	register("OSVPCEndpoint", ListOSVPCEndpoints)
+}
+
+func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
+	svc := opensearchservice.New(sess)
+
+	listResp, err := svc.DescribeVpcEndpoints(&opensearchservice.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []*string{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]Resource, 0)
+
+	for _, vpcEndpoint := range listResp.VpcEndpoints {
+		resources = append(resources, &OSVPCEndpoint{
+			svc:           svc,
+			vpcEndpointId: vpcEndpoint.VpcEndpointId,
+		})
+	}
+
+	return resources, nil
+}
+
+func (o *OSVPCEndpoint) Remove() error {
+	_, err := o.svc.DeleteVpcEndpoint(&opensearchservice.DeleteVpcEndpointInput{
+		VpcEndpointId: o.vpcEndpointId,
+	})
+
+	return err
+}
+
+func (o *OSVPCEndpoint) Properties() types.Properties {
+	properties := types.NewProperties()
+	return properties
+}
+
+func (o *OSVPCEndpoint) String() string {
+	return *o.vpcEndpointId
+}

--- a/resources/opensearchservice-vpcendpoints.go
+++ b/resources/opensearchservice-vpcendpoints.go
@@ -18,8 +18,13 @@ func init() {
 func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
 	svc := opensearchservice.New(sess)
 
+	vpcEndpointIds, err := getOpenSearchVpcEndpointIds(svc)
+	if err != nil {
+		return nil, err
+	}
+
 	listResp, err := svc.DescribeVpcEndpoints(&opensearchservice.DescribeVpcEndpointsInput{
-		VpcEndpointIds: []*string{},
+		VpcEndpointIds: vpcEndpointIds,
 	})
 	if err != nil {
 		return nil, err
@@ -35,6 +40,21 @@ func ListOSVPCEndpoints(sess *session.Session) ([]Resource, error) {
 	}
 
 	return resources, nil
+}
+
+func getOpenSearchVpcEndpointIds(svc *opensearchservice.OpenSearchService) ([]*string, error) {
+	vpcEndpointIds := make([]*string, 0)
+
+	listResp, err := svc.ListVpcEndpoints(&opensearchservice.ListVpcEndpointsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vpcEndpoint := range listResp.VpcEndpointSummaryList {
+		vpcEndpointIds = append(vpcEndpointIds, vpcEndpoint.VpcEndpointId)
+	}
+
+	return vpcEndpointIds, nil
 }
 
 func (o *OSVPCEndpoint) Remove() error {


### PR DESCRIPTION
This PR includes two new modules for OpenSearch packages and VPC Endpoints.

Tests scripts are included in the related [PR](https://github.com/oreillymedia/cl-tf-aws/pull/13).