### PR TITLE
Adding rekognition project and dataset support.

### DIFF
--- a/resources/rekognition-dataset.go
+++ b/resources/rekognition-dataset.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rekognition"
+)
+
+type RekognitionDataset struct {
+	svc *rekognition.Rekognition
+	arn *string
+}
+
+func init() {
+	register("RekognitionDataset", ListRekognitionDatasets)
+}
+
+func ListRekognitionDatasets(sess *session.Session) ([]Resource, error) {
+	svc := rekognition.New(sess)
+	resources := []Resource{}
+
+	params := &rekognition.DescribeProjectsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.DescribeProjects(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, project := range output.ProjectDescriptions {
+			for _, dataset := range project.Datasets {
+				resources = append(resources, &RekognitionDataset{
+					svc: svc,
+					arn: dataset.DatasetArn,
+				})
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RekognitionDataset) Remove() error {
+
+	_, err := f.svc.DeleteDataset(&rekognition.DeleteDatasetInput{
+		DatasetArn: f.arn,
+	})
+
+	return err
+}
+
+func (f *RekognitionDataset) String() string {
+	return *f.arn
+}

--- a/resources/rekognition-project.go
+++ b/resources/rekognition-project.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rekognition"
+)
+
+type RekognitionProject struct {
+	svc *rekognition.Rekognition
+	arn *string
+}
+
+func init() {
+	register("RekognitionProject", ListRekognitionProjects)
+}
+
+func ListRekognitionProjects(sess *session.Session) ([]Resource, error) {
+	svc := rekognition.New(sess)
+	resources := []Resource{}
+
+	params := &rekognition.DescribeProjectsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.DescribeProjects(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, project := range output.ProjectDescriptions {
+			resources = append(resources, &RekognitionProject{
+				svc: svc,
+				arn: project.ProjectArn,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *RekognitionProject) Remove() error {
+
+	_, err := f.svc.DeleteProject(&rekognition.DeleteProjectInput{
+		ProjectArn: f.arn,
+	})
+
+	return err
+}
+
+func (f *RekognitionProject) String() string {
+	return *f.arn
+}


### PR DESCRIPTION
This PR includes two new modules for Rekogniton, projects and datasets.

Tests scripts are included in the related [PR](https://github.com/oreillymedia/cl-tf-aws/pull/21).

Note: Rekogniton datasets don't have list functions directly available.  This info has been parsed from the DescribeProjects call.