### PR TITLE
Support for additional codebuild resources 

### DIFF
--- a/resources/codebuild-build-batches.go
+++ b/resources/codebuild-build-batches.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CodeBuildBuildBatch struct {
+	svc *codebuild.CodeBuild
+	Id  *string
+}
+
+func init() {
+	register("CodeBuildBuildBatch", ListCodeBuildBuildBatch)
+}
+
+func ListCodeBuildBuildBatch(sess *session.Session) ([]Resource, error) {
+	svc := codebuild.New(sess)
+	resources := []Resource{}
+
+	params := &codebuild.ListBuildBatchesInput{}
+
+	for {
+		resp, err := svc.ListBuildBatches(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, batch := range resp.Ids {
+			resources = append(resources, &CodeBuildBuildBatch{
+				svc: svc,
+				Id:  batch,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *CodeBuildBuildBatch) Remove() error {
+	_, err := f.svc.DeleteBuildBatch(&codebuild.DeleteBuildBatchInput{
+		Id: f.Id,
+	})
+
+	return err
+}
+
+func (f *CodeBuildBuildBatch) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("Id", f.Id)
+	return properties
+}

--- a/resources/codebuild-builds.go
+++ b/resources/codebuild-builds.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CodeBuildBuild struct {
+	svc *codebuild.CodeBuild
+	Id  *string
+}
+
+func init() {
+	register("CodeBuildBuild", ListCodeBuildBuild)
+}
+
+func ListCodeBuildBuild(sess *session.Session) ([]Resource, error) {
+	svc := codebuild.New(sess)
+	resources := []Resource{}
+
+	params := &codebuild.ListBuildsInput{}
+
+	for {
+		resp, err := svc.ListBuilds(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, build := range resp.Ids {
+			resources = append(resources, &CodeBuildBuild{
+				svc: svc,
+				Id:  build,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *CodeBuildBuild) Remove() error {
+	_, err := f.svc.BatchDeleteBuilds(&codebuild.BatchDeleteBuildsInput{
+		Ids: []*string{f.Id},
+	})
+
+	return err
+}
+
+func (f *CodeBuildBuild) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("Id", f.Id)
+	return properties
+}

--- a/resources/codebuild-report-group.go
+++ b/resources/codebuild-report-group.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CodeBuildReportGroup struct {
+	svc *codebuild.CodeBuild
+	Arn *string
+}
+
+func init() {
+	register("CodeBuildReportGroup", ListCodeBuildReportGroup)
+}
+
+func ListCodeBuildReportGroup(sess *session.Session) ([]Resource, error) {
+	svc := codebuild.New(sess)
+	resources := []Resource{}
+
+	params := &codebuild.ListReportGroupsInput{}
+
+	for {
+		resp, err := svc.ListReportGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, reportGroup := range resp.ReportGroups {
+			resources = append(resources, &CodeBuildReportGroup{
+				svc: svc,
+				Arn: reportGroup,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *CodeBuildReportGroup) Remove() error {
+	_, err := f.svc.DeleteReportGroup(&codebuild.DeleteReportGroupInput{
+		Arn: f.Arn,
+	})
+
+	return err
+}
+
+func (f *CodeBuildReportGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("Arn", f.Arn)
+	return properties
+}

--- a/resources/codebuild-source-credentials.go
+++ b/resources/codebuild-source-credentials.go
@@ -24,12 +24,9 @@ func ListCodeBuildSourceCredential(sess *session.Session) ([]Resource, error) {
 	params := &codebuild.ListSourceCredentialsInput{}
 
 	resp, err := svc.ListSourceCredentials(params)
+
 	if err != nil {
 		return nil, err
-	}
-
-	if resp == nil {
-		return nil, nil
 	}
 
 	for _, credential := range resp.SourceCredentialsInfos {

--- a/resources/codebuild-source-credentials.go
+++ b/resources/codebuild-source-credentials.go
@@ -1,0 +1,57 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CodeBuildSourceCredential struct {
+	svc        *codebuild.CodeBuild
+	Arn        *string
+	AuthType   *string
+	ServerType *string
+}
+
+func init() {
+	register("CodeBuildSourceCredential", ListCodeBuildSourceCredential)
+}
+
+func ListCodeBuildSourceCredential(sess *session.Session) ([]Resource, error) {
+	svc := codebuild.New(sess)
+	resources := []Resource{}
+
+	params := &codebuild.ListSourceCredentialsInput{}
+
+	resp, err := svc.ListSourceCredentials(params)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp == nil {
+		return nil, nil
+	}
+
+	for _, credential := range resp.SourceCredentialsInfos {
+		resources = append(resources, &CodeBuildSourceCredential{
+			svc: svc,
+			Arn: credential.Arn,
+		})
+	}
+
+	return resources, nil
+}
+
+func (f *CodeBuildSourceCredential) Remove() error {
+	_, err := f.svc.DeleteSourceCredentials(&codebuild.DeleteSourceCredentialsInput{Arn: f.Arn})
+	return err
+}
+
+func (f *CodeBuildSourceCredential) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Arn", f.Arn)
+	properties.Set("AuthType", f.AuthType)
+	properties.Set("ServerType", f.ServerType)
+
+	return properties
+}


### PR DESCRIPTION
This PR includes new modules to handle Codebuild builds, build batches, report groups, and source credentials. Adding support for webhooks and reports was not needed as these resources depend on the project and project's builds respectively.

## Testing
After creating the codebuild resources using the script mentioned below, run aws-nuke specifying the following resources:
- CodeBuildBuild
- CodeBuildProject
- CodeBuildSourceCredential
- CodeBuildBuildBatch
- CodeBuildReportGroup

Once aws-nuke finishes, verify that there are no resources left with the following commands:
```
echo "Listing projects"
aws codebuild list-projects 
echo "Listing report groups"
aws codebuild list-report-groups 
echo "Listing source credentials"
aws codebuild list-source-credentials
echo "Listing builds"
aws codebuild list-builds
echo "Listing build batches"
aws codebuild list-build-batches
```

## Setup

```
#!/bin/bash

# Get AWS account ID
AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
echo "AWS Account ID: $AWS_ACCOUNT_ID"

# Generate a random number
randomNum=$(cat /dev/urandom | LANG=c tr -dc '0-9' | head -c 12)
echo "Random number: $randomNum"

# create a service role for codebuild
aws iam create-role --role-name CodeBuildServiceRole --assume-role-policy-document '{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Service": "codebuild.amazonaws.com"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}'

# attach policies to the codebuild service role
aws iam attach-role-policy --role-name CodeBuildServiceRole --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess
aws iam attach-role-policy --role-name CodeBuildServiceRole --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess

# create source code 
mkdir -p src/main/java
mkdir -p src/test/java

cat <<EOF >./src/main/java/MessageUtil.java
public class MessageUtil {
  private String message;

  public MessageUtil(String message) {
    this.message = message;
  }

  public String printMessage() {
    System.out.println(message);
    return message;
  }

  public String salutationMessage() {
    message = "Hi!" + message;
    System.out.println(message);
    return message;
  }
}
EOF

cat <<EOF >./src/test/java/TestMessageUtil.java
import org.junit.Test;
import org.junit.Ignore;
import static org.junit.Assert.assertEquals;

public class TestMessageUtil {

  String message = "Robert";    
  MessageUtil messageUtil = new MessageUtil(message);
   
  @Test
  public void testPrintMessage() {      
    System.out.println("Inside testPrintMessage()");     
    assertEquals(message,messageUtil.printMessage());
  }

  @Test
  public void testSalutationMessage() {
    System.out.println("Inside testSalutationMessage()");
    message = "Hi!" + "Robert";
    assertEquals(message,messageUtil.salutationMessage());
  }
}
EOF

cat <<EOF >pom.xml
<project xmlns="http://maven.apache.org/POM/4.0.0" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.example</groupId>
  <artifactId>messageUtil</artifactId>
  <version>1.0</version>
  <packaging>jar</packaging>
  <name>Message Utility Java Sample App</name>
  <dependencies>
    <dependency>
      <groupId>junit</groupId>
      <artifactId>junit</artifactId>
      <version>4.11</version>
      <scope>test</scope>
    </dependency>	
  </dependencies>
  <build>
    <plugins>
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-compiler-plugin</artifactId>
        <version>3.8.0</version>
      </plugin>
    </plugins>
  </build>
</project>
EOF

# create the buildspec file
cat <<EOF >buildspec.yml
version: 0.2

phases:
  install:
    runtime-versions:
      java: corretto11
  pre_build:
    commands:
      - echo Nothing to do in the pre_build phase...
  build:
    commands:
      - echo Build started on `date`
      - mvn install
  post_build:
    commands:
      - echo Build completed on `date`
artifacts:
  files:
    - target/messageUtil-1.0.jar
EOF

# create a codebuild project spec
cat <<EOF >create-project.json
{
  "name": "codebuild-demo-project",
  "source": {
    "type": "S3",
    "location": "codebuild-$randomNum-input/MessageUtil.zip"
  },
  "artifacts": {
    "type": "S3",
    "location": "codebuild-$randomNum-output"
  },
  "environment": {
    "type": "LINUX_CONTAINER",
    "image": "aws/codebuild/standard:5.0",
    "computeType": "BUILD_GENERAL1_SMALL"
  },
  "serviceRole": "arn:aws:iam::$AWS_ACCOUNT_ID:role/CodeBuildServiceRole",
  "buildBatchConfig": {
    "serviceRole": "arn:aws:iam::$AWS_ACCOUNT_ID:role/CodeBuildServiceRole",
    "combineArtifacts": false,
    "restrictions": {
        "maximumBuildsAllowed": 2,
        "computeTypesAllowed": ["BUILD_GENERAL1_SMALL"]
    },
    "timeoutInMins": 10
  }
}
EOF

# create two S3 buckets
aws s3api create-bucket --bucket codebuild-$randomNum-input --no-cli-pager
aws s3api create-bucket --bucket codebuild-$randomNum-output --no-cli-pager

# Create a zip file of the source code
zip -r  MessageUtil.zip ./src/* pom.xml buildspec.yml

# Upload the source code to the S3 bucket
aws s3 cp MessageUtil.zip s3://codebuild-$randomNum-input

aws codebuild create-project --cli-input-json file://create-project.json --no-cli-pager

# create a codebuild report group
cat <<EOF >create-report-group-source.json
{
    "name": "cli-created-report-group",
    "type": "TEST",
    "exportConfig": {
        "exportConfigType": "S3",
        "s3Destination": {
            "bucket": "codebuild-$randomNum-output",
            "path": "",
            "packaging": "ZIP",
            "encryptionDisabled": true
        }
    }
}
EOF
aws codebuild create-report-group \
    --cli-input-json file://create-report-group-source.json \
    --no-cli-pager

# import source credentials
aws codebuild import-source-credentials --server-type BITBUCKET --auth-type BASIC_AUTH --token my-Bitbucket-password --username my-Bitbucket-username

# start a codebuild build
aws codebuild start-build --project-name codebuild-demo-project

# start a codebuild build batch
aws codebuild start-build-batch --project-name codebuild-demo-project
```