### PR TITLE
Add CodeGuru Reviewer RepositoryAssociation support

### DIFF
--- a/resources/codegurureviewer-repository-associations.go
+++ b/resources/codegurureviewer-repository-associations.go
@@ -16,7 +16,8 @@ type CodeGuruReviewerRepositoryAssociation struct {
 }
 
 func init() {
-	register("CodeGuruReviewerRepositoryAssociation", ListCodeGuruReviewerRepositoryAssociations)
+	register("CodeGuruReviewerRepositoryAssociation", ListCodeGuruReviewerRepositoryAssociations,
+		mapCloudControl("AWS::CodeGuruReviewer::RepositoryAssociation"))
 }
 
 func ListCodeGuruReviewerRepositoryAssociations(sess *session.Session) ([]Resource, error) {

--- a/resources/codegurureviewer-repository-associations.go
+++ b/resources/codegurureviewer-repository-associations.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codegurureviewer"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CodeGuruReviewerRepositoryAssociation struct {
+	svc            *codegurureviewer.CodeGuruReviewer
+	AssociationArn *string
+	AssociationId  *string
+	Name           *string
+	Owner          *string
+	ProviderType   *string
+}
+
+func init() {
+	register("CodeGuruReviewerRepositoryAssociation", ListCodeGuruReviewerRepositoryAssociations)
+}
+
+func ListCodeGuruReviewerRepositoryAssociations(sess *session.Session) ([]Resource, error) {
+	svc := codegurureviewer.New(sess)
+	resources := []Resource{}
+
+	params := &codegurureviewer.ListRepositoryAssociationsInput{}
+
+	for {
+		resp, err := svc.ListRepositoryAssociations(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, association := range resp.RepositoryAssociationSummaries {
+			resources = append(resources, &CodeGuruReviewerRepositoryAssociation{
+				svc:            svc,
+				AssociationArn: association.AssociationArn,
+				AssociationId:  association.AssociationId,
+				Name:           association.Name,
+				Owner:          association.Owner,
+				ProviderType:   association.ProviderType,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *CodeGuruReviewerRepositoryAssociation) Remove() error {
+	_, err := f.svc.DisassociateRepository(&codegurureviewer.DisassociateRepositoryInput{
+		AssociationArn: f.AssociationArn,
+	})
+	return err
+}
+
+func (f *CodeGuruReviewerRepositoryAssociation) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("AssociationArn", f.AssociationArn)
+	properties.Set("AssociationId", f.AssociationId)
+	properties.Set("Name", f.Name)
+	properties.Set("Owner", f.Owner)
+	properties.Set("ProviderType", f.ProviderType)
+	return properties
+}


### PR DESCRIPTION
Attempting to delete CodeGuru `RepositoryAssociations` using the Cloud Control API (`AWS::CodeGuruReviewer::RepositoryAssociation`) results in these errors:

```
 Errors: time="2023-10-24T20:45:26Z" level=error msg="Listing AWS::CodeGuruReviewer::RepositoryAssociation failed:\n    GeneralServiceException: AWS::CodeGuruReviewer::RepositoryAssociation Handler returned status FAILED: The security token included in the request is invalid (Service: CodeGuruReviewer, Status Code: 403, Request ID: f3bbe738-5aec-48a9-be48-facd30973c11) (HandlerErrorCode: GeneralServiceException, RequestToken: 7b035a0f-71c4-4271-97bd-da5984d361a8)"
```

This PR adds a new module to support CodeGuru `RepositoryAssociations`.

## Testing

Create Codecommit and CodeGuru resources:

```
#!/bin/bash

echo "create a codecommit repository"
aws codecommit create-repository --repository-name MyDemoRepo

echo "create a codeguru repository association"
aws codeguru-reviewer associate-repository \
    --repository CodeCommit={Name=MyDemoRepo}
```

Then run aws-nuke specifying `CodeGuruReviewerRepositoryAssociation` resource.

And finally, verify if the resource was cleanup correctly, by running 

```
aws codeguru-reviewer list-repository-associations
```