### PR TITLE
Patch Route53ResolverRule early

### DIFF
--- a/resources/route53-resolver-rules.go
+++ b/resources/route53-resolver-rules.go
@@ -100,7 +100,7 @@ func resolverRulesToVpcIDs(svc *route53resolver.Route53Resolver) (map[string][]*
 
 // Filter removes resources automatically from being nuked
 func (r *Route53ResolverRule) Filter() error {
-	if *r.domainName == "." {
+	if r.domainName != nil && *r.domainName == "." {
 		return fmt.Errorf(`Filtering DomainName "."`)
 	}
 


### PR DESCRIPTION
This merges in https://github.com/rebuy-de/aws-nuke/pull/1134 so we are not waiting for an official release to avoid the following error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x36b86dc]

goroutine 1 [running]:
github.com/rebuy-de/aws-nuke/v2/resources.(*Route53ResolverRule).Filter(0x400070b3a8?)
        /home/runner/work/aws-nuke/aws-nuke/resources/route53-resolver-rules.go:103 +0x1c
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Filter(0x40004b54a0, 0x400086d5c0)
        /home/runner/work/aws-nuke/aws-nuke/cmd/nuke.go:206 +0x4c
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Scan(0x40004b54a0)
        /home/runner/work/aws-nuke/aws-nuke/cmd/nuke.go:183 +0x730
github.com/rebuy-de/aws-nuke/v2/cmd.(*Nuke).Run(0x40004b54a0)
        /home/runner/work/aws-nuke/aws-nuke/cmd/nuke.go:61 +0x2ac
github.com/rebuy-de/aws-nuke/v2/cmd.NewRootCommand.func2(0x4000440700?, {0x53ddc45?, 0x4?, 0x53ddc49?})
        /home/runner/work/aws-nuke/aws-nuke/cmd/root.go:92 +0x5e0
github.com/spf13/cobra.(*Command).execute(0x40003ba300, {0x40001921b0, 0xc, 0xc})
        /home/runner/work/aws-nuke/aws-nuke/vendor/github.com/spf13/cobra/command.go:940 +0x658
github.com/spf13/cobra.(*Command).ExecuteC(0x40003ba300)
        /home/runner/work/aws-nuke/aws-nuke/vendor/github.com/spf13/cobra/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(0x8fb0fa8?)
        /home/runner/work/aws-nuke/aws-nuke/vendor/github.com/spf13/cobra/command.go:992 +0x1c
main.main()
        /home/runner/work/aws-nuke/aws-nuke/main.go:10 +0x20
```
