### PR TITLE
CL-858 Adding Athena support for data catalogs and prepared statements

### DIFF
--- a/resources/athena-data-catalogs.go
+++ b/resources/athena-data-catalogs.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type AthenaDataCatalog struct {
+	svc  *athena.Athena
+	name *string
+}
+
+func init() {
+	register("AthenaDataCatalog", ListAthenaDataCatalogs)
+}
+
+func ListAthenaDataCatalogs(sess *session.Session) ([]Resource, error) {
+	svc := athena.New(sess)
+	resources := []Resource{}
+
+	params := &athena.ListDataCatalogsInput{
+		MaxResults: aws.Int64(50),
+	}
+
+	for {
+		output, err := svc.ListDataCatalogs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, catalog := range output.DataCatalogsSummary {
+			resources = append(resources, &AthenaDataCatalog{
+				svc:  svc,
+				name: catalog.CatalogName,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *AthenaDataCatalog) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", f.name)
+
+	return properties
+}
+
+func (f *AthenaDataCatalog) Remove() error {
+
+	_, err := f.svc.DeleteDataCatalog(&athena.DeleteDataCatalogInput{
+		Name: f.name,
+	})
+
+	return err
+}
+
+func (f *AthenaDataCatalog) Filter() error {
+	if *f.name == "AwsDataCatalog" {
+		return fmt.Errorf("cannot delete default data source")
+	}
+	return nil
+}
+
+func (f *AthenaDataCatalog) String() string {
+	return *f.name
+}

--- a/resources/athena-prepared-statements.go
+++ b/resources/athena-prepared-statements.go
@@ -1,0 +1,80 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type AthenaPreparedStatement struct {
+	svc       *athena.Athena
+	workGroup *string
+	name      *string
+}
+
+func init() {
+	register("AthenaPreparedStatement", ListAthenaPreparedStatements)
+}
+
+func ListAthenaPreparedStatements(sess *session.Session) ([]Resource, error) {
+	svc := athena.New(sess)
+	resources := []Resource{}
+
+	workgroups, err := svc.ListWorkGroups(&athena.ListWorkGroupsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, workgroup := range workgroups.WorkGroups {
+		params := &athena.ListPreparedStatementsInput{
+			WorkGroup:  workgroup.Name,
+			MaxResults: aws.Int64(50),
+		}
+
+		for {
+			output, err := svc.ListPreparedStatements(params)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, statement := range output.PreparedStatements {
+				resources = append(resources, &AthenaPreparedStatement{
+					svc:       svc,
+					workGroup: workgroup.Name,
+					name:      statement.StatementName,
+				})
+			}
+
+			if output.NextToken == nil {
+				break
+			}
+
+			params.NextToken = output.NextToken
+		}
+	}
+
+	return resources, nil
+}
+
+func (f *AthenaPreparedStatement) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("StatementName", f.name)
+	properties.Set("WorkGroup", f.workGroup)
+
+	return properties
+}
+
+func (f *AthenaPreparedStatement) Remove() error {
+
+	_, err := f.svc.DeletePreparedStatement(&athena.DeletePreparedStatementInput{
+		StatementName: f.name,
+		WorkGroup:     f.workGroup,
+	})
+
+	return err
+}
+
+func (f *AthenaPreparedStatement) String() string {
+	return *f.name
+}


### PR DESCRIPTION
This PR adds support for AWS athena data catalogs and prepared statements.

The test script for creating these resources can be found [here](https://github.com/oreillymedia/cl-tf-aws/blob/232052263a0e7609f14749e491d4cab772190336/terraform/cl-aws-policies/tests/athena.sh.) 

### Note
These resource types show supported by cloud control, but when using the cloud control resource types to attempt to clean these resources, they failed to find user created resources in my testing.