### PR TITLE
CL-508 Adding support for CloudWatch Insight Rules

### DIFF
--- a/resources/cloudwatch-anomaly-detectors.go
+++ b/resources/cloudwatch-anomaly-detectors.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudWatchAnomalyDetector struct {
+	svc      *cloudwatch.CloudWatch
+	detector *cloudwatch.AnomalyDetector
+}
+
+func init() {
+	register("CloudWatchAnomalyDetector", ListCloudWatchAnomalyDetectors)
+}
+
+func ListCloudWatchAnomalyDetectors(sess *session.Session) ([]Resource, error) {
+	svc := cloudwatch.New(sess)
+	resources := []Resource{}
+
+	params := &cloudwatch.DescribeAnomalyDetectorsInput{
+		MaxResults: aws.Int64(25),
+	}
+
+	for {
+		output, err := svc.DescribeAnomalyDetectors(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, detector := range output.AnomalyDetectors {
+			resources = append(resources, &CloudWatchAnomalyDetector{
+				svc:      svc,
+				detector: detector,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *CloudWatchAnomalyDetector) Remove() error {
+	_, err := f.svc.DeleteAnomalyDetector(&cloudwatch.DeleteAnomalyDetectorInput{
+		SingleMetricAnomalyDetector: f.detector.SingleMetricAnomalyDetector,
+	})
+
+	return err
+}
+
+func (f *CloudWatchAnomalyDetector) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("MetricName", f.detector.SingleMetricAnomalyDetector.MetricName)
+	return properties
+}
+
+func (f *CloudWatchAnomalyDetector) String() string {
+	return *f.detector.SingleMetricAnomalyDetector.MetricName
+}

--- a/resources/cloudwatch-insight-rules.go
+++ b/resources/cloudwatch-insight-rules.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudWatchInsightRule struct {
+	svc  *cloudwatch.CloudWatch
+	name *string
+}
+
+func init() {
+	register("CloudWatchInsightRule", ListCloudWatchInsightRules)
+}
+
+func ListCloudWatchInsightRules(sess *session.Session) ([]Resource, error) {
+	svc := cloudwatch.New(sess)
+	resources := []Resource{}
+
+	params := &cloudwatch.DescribeInsightRulesInput{
+		MaxResults: aws.Int64(25),
+	}
+
+	for {
+		output, err := svc.DescribeInsightRules(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rules := range output.InsightRules {
+			resources = append(resources, &CloudWatchInsightRule{
+				svc:  svc,
+				name: rules.Name,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *CloudWatchInsightRule) Remove() error {
+	_, err := f.svc.DeleteInsightRules(&cloudwatch.DeleteInsightRulesInput{
+		RuleNames: []*string{f.name},
+	})
+
+	return err
+}
+
+func (f *CloudWatchInsightRule) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", f.name)
+	return properties
+}
+
+func (f *CloudWatchInsightRule) String() string {
+	return *f.name
+}


### PR DESCRIPTION
This PR adds support for AWS CloudWatch insight rules and anomaly detectors.

The test script for creating these resources can be found [here](https://github.com/oreillymedia/cl-tf-aws/pull/44/files)
