### PR TITLE
CL-880 Elastic Transcoder Preset support.

### DIFF
--- a/resources/elastictranscoder-preset.go
+++ b/resources/elastictranscoder-preset.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elastictranscoder"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type ElasticTranscoderPreset struct {
+	svc      *elastictranscoder.ElasticTranscoder
+	presetID *string
+}
+
+func init() {
+	register("ElasticTranscoderPreset", ListElasticTranscoderPresets)
+}
+
+func ListElasticTranscoderPresets(sess *session.Session) ([]Resource, error) {
+	svc := elastictranscoder.New(sess)
+	resources := []Resource{}
+
+	params := &elastictranscoder.ListPresetsInput{}
+
+	for {
+		resp, err := svc.ListPresets(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, preset := range resp.Presets {
+			resources = append(resources, &ElasticTranscoderPreset{
+				svc:      svc,
+				presetID: preset.Id,
+			})
+		}
+
+		if resp.NextPageToken == nil {
+			break
+		}
+
+		params.PageToken = resp.NextPageToken
+	}
+
+	return resources, nil
+}
+
+func (f *ElasticTranscoderPreset) Filter() error {
+	if strings.HasPrefix(*f.presetID, "1351620000001") {
+		return fmt.Errorf("cannot delete elastic transcoder system presets")
+	}
+	return nil
+}
+
+func (f *ElasticTranscoderPreset) Remove() error {
+
+	_, err := f.svc.DeletePreset(&elastictranscoder.DeletePresetInput{
+		Id: f.presetID,
+	})
+
+	return err
+}
+
+func (f *ElasticTranscoderPreset) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("PresetID", f.presetID)
+	return properties
+}
+
+func (f *ElasticTranscoderPreset) String() string {
+	return *f.presetID
+}


### PR DESCRIPTION
This PR adds support for ElasticTranscoder Preset Support.

ElasticTranscoder resources were created using the setup code found [here](https://github.com/oreillymedia/cl-tf-aws/pull/46/files), and then AWS Nuke was used to clean these new resources up, specifying :

"ElasticTranscoderPipeline"
"ElasticTranscoderPreset"
"MQBroker"

### Note
ElasticTranscoder jobs are deleted when the pipeline is deleted.
MQ Users are deleted when the broker is deleted.  MQ Configurations are not able to be deleted.  They are created automatically when an MQ Broker is created or you can create a custom configuration, but these don't contain user identifiable information.   