### PR TITLE
Add module to handle Glue security configurations

### DIFF
--- a/resources/glue-securityconfigurations.go
+++ b/resources/glue-securityconfigurations.go
@@ -38,7 +38,7 @@ func ListGlueSecurityConfigurations(sess *session.Session) ([]Resource, error) {
 		}
 
 		// Check if there are more security configurations to fetch
-		if output.NextToken == nil || *output.NextToken == ""{
+		if output.NextToken == nil || *output.NextToken == "" {
 			break
 		}
 

--- a/resources/glue-securityconfigurations.go
+++ b/resources/glue-securityconfigurations.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type GlueSecurityConfiguration struct {
+	svc  *glue.Glue
+	name *string
+}
+
+func init() {
+	register("GlueSecurityConfiguration", ListGlueSecurityConfigurations)
+}
+
+func ListGlueSecurityConfigurations(sess *session.Session) ([]Resource, error) {
+	svc := glue.New(sess)
+	resources := []Resource{}
+
+	params := &glue.GetSecurityConfigurationsInput{
+		MaxResults: aws.Int64(25),
+	}
+
+	for {
+		output, err := svc.GetSecurityConfigurations(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, securityConfiguration := range output.SecurityConfigurations {
+			resources = append(resources, &GlueSecurityConfiguration{
+				svc:  svc,
+				name: securityConfiguration.Name,
+			})
+		}
+
+		// Check if there are more security configurations to fetch
+		if output.NextToken == nil || *output.NextToken == ""{
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *GlueSecurityConfiguration) Remove() error {
+	_, err := f.svc.DeleteSecurityConfiguration(&glue.DeleteSecurityConfigurationInput{
+		Name: f.name,
+	})
+
+	return err
+}
+
+func (f *GlueSecurityConfiguration) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("Name", f.name)
+
+	return properties
+}
+
+func (f *GlueSecurityConfiguration) String() string {
+	return *f.name
+}


### PR DESCRIPTION
This PR adds a new module to handle Glue Security Configurations. This module was written by @swhite-oreilly, with the only difference that when checking for the next token apart from checking for nil, it checks for an empty string. That was causing aws-nuke to hang when trying to delete this resource.

## Testing

1. Use a test account, and create the glue security configuration
```
# Create a KMS key
KMS_KEY_ARN=$(aws kms create-key --query 'KeyMetadata.Arn' --output text)
echo "KMS key created: $KMS_KEY_ARN"

# Create a Glue security configuration with the created KMS key ARN
aws glue create-security-configuration \
    --name "testSecurityConfig" \
    --encryption-configuration '{
        "S3Encryption": [
            {
                "S3EncryptionMode": "SSE-KMS",
                "KmsKeyArn": "'"$KMS_KEY_ARN"'"
            }
        ],
        "CloudWatchEncryption": {
            "CloudWatchEncryptionMode": "SSE-KMS",
            "KmsKeyArn": "'"$KMS_KEY_ARN"'"
        },
        "JobBookmarksEncryption": {
            "JobBookmarksEncryptionMode": "CSE-KMS",
            "KmsKeyArn": "'"$KMS_KEY_ARN"'"
        }
    }'
echo "Glue security configuration created"

# Listing security configurations
aws glue get-security-configurations
```

2. Run aws-nuke against the selected account
3. Check that glue security configurations were correctly deleted  `aws glue get-security-configurations`