### PR TITLE
CL-534 | add KinesisSignalingChannels module

### DIFF
--- a/resources/kinesis-signaling-channels.go
+++ b/resources/kinesis-signaling-channels.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kinesisvideo"
+)
+
+type KinesisSignalingChannels struct {
+	svc        *kinesisvideo.KinesisVideo
+	ChannelARN *string
+}
+
+func init() {
+	register("KinesisSignalingChannels", ListKinesisSignalingChannels)
+}
+
+func ListKinesisSignalingChannels(sess *session.Session) ([]Resource, error) {
+	svc := kinesisvideo.New(sess)
+	resources := []Resource{}
+
+	params := &kinesisvideo.ListSignalingChannelsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListSignalingChannels(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, streamInfo := range output.ChannelInfoList {
+			resources = append(resources, &KinesisSignalingChannels{
+				svc:        svc,
+				ChannelARN: streamInfo.ChannelARN,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		params.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *KinesisSignalingChannels) Remove() error {
+
+	_, err := f.svc.DeleteSignalingChannel(&kinesisvideo.DeleteSignalingChannelInput{
+		ChannelARN: f.ChannelARN,
+	})
+
+	return err
+}
+
+func (f *KinesisSignalingChannels) String() string {
+	return *f.ChannelARN
+}


### PR DESCRIPTION
Description
--
This PR adds a new module for cleaning up kinesis signaling channels. 

Testing
--

1.  Create the signaling channel
`aws kinesisvideo create-signaling-channel --channel-name test-channel`

2. Run aws-nuke and include the `KinesisSignalingChannels` module
```
aws-nuke version unknown - unknown - unknown

Do you really want to nuke the account with the ID 12345 and the alias 'alias-12345'?
Waiting 3s before continuing.
us-east-1 - KinesisSignalingChannels - arn:aws:kinesisvideo:us-east-1:12345:channel/test-channel/12345 - would remove
us-east-1 - KinesisSignalingChannels - arn:aws:kinesisvideo:us-east-1:12345:channel/test-channel-234234/12345 - would remove
Scan complete: 2 total, 2 nukeable, 0 filtered.

Do you really want to nuke these resources on the account with the ID 12345 and the alias 'alias-384736907310'?
Waiting 3s before continuing.
us-east-1 - KinesisSignalingChannels - arn:aws:kinesisvideo:us-east-1:12345:channel/test-channel/123456 - triggered remove
us-east-1 - KinesisSignalingChannels - arn:aws:kinesisvideo:us-east-1:12345:channel/test-channel-234234/12345 - triggered remove
	
Removal requested: 2 waiting, 0 failed, 0 skipped, 0 finished
```
3. Verify the resources have been deleted
`aws kinesisvideo list-signaling-channels`
