### PR TITLE
Filter additional "pkg-*" default packages

### DIFF
--- a/resources/opensearchservice-packages.go
+++ b/resources/opensearchservice-packages.go
@@ -57,7 +57,7 @@ func ListOSPackages(sess *session.Session) ([]Resource, error) {
 }
 
 func (o *OSPackage) Filter() error {
-	if strings.HasPrefix(*o.packageID, "G") {
+	if strings.HasPrefix(*o.packageID, "G") || strings.HasPrefix(*o.packageID, "pkg-") {
 		return fmt.Errorf("cannot delete default opensearch packages")
 	}
 	return nil


### PR DESCRIPTION
Additional default OpenSearch packages are now showing up in AWS accounts and breaking our AWS Nuke process. This should filter them out accordingly.
![image](https://github.com/user-attachments/assets/db87c0ae-e313-48ce-bf55-85c562e0a227)
